### PR TITLE
hotfix

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,10 @@
 CHANGES
 =======
 
+## 2011-04-15 0.1.1
+-------------------
+* Fix bug with empty request.data on PUT method when content-type is 'application/x-www-form-urlencoded'
+
 ## 2011-04-12 0.1.0
 -------------------
 * Fix invalid identifier in url

--- a/adrest/__init__.py
+++ b/adrest/__init__.py
@@ -1,4 +1,4 @@
-version_info = (0, 1, 0)
+version_info = (0, 1, 1)
 
 __version__ = version = '.'.join(map(str, version_info))
 __project__ = PROJECT = __name__

--- a/adrest/parsers.py
+++ b/adrest/parsers.py
@@ -1,3 +1,4 @@
+from django.http import QueryDict
 from django.utils import simplejson as json
 
 from adrest import status
@@ -62,4 +63,8 @@ class FormParser(BaseParser):
     media_type = 'application/x-www-form-urlencoded'
 
     def parse(self):
-        return dict(self.resource.request.REQUEST.iteritems())
+        source = self.resource.request.REQUEST.iteritems()
+        if self.resource.request.method == "PUT":
+            # Fix django bug: request.GET, .POST are empty on PUT request
+            source = QueryDict(self.resource.request.raw_post_data, encoding=self.resource.request.encoding).iteritems()
+        return dict(source)


### PR DESCRIPTION
Fix bug with empty request.data on PUT method when content-type is 'application/x-www-form-urlencoded'
