### PR TITLE
Removed unused field from paginator

### DIFF
--- a/adrest/utils/paginator.py
+++ b/adrest/utils/paginator.py
@@ -13,7 +13,6 @@ class Paginator(object):
         self.query_dict = dict(request.GET.items())
         self.paginator = DjangoPaginator(qs, int(self.query_dict.get('max') or max_res))
         self.path = request.path
-        self.name = qs.model._meta.module_name
         page_num = int(request.REQUEST.get('page', 1))
         try:
             self.page = self.paginator.page(page_num)


### PR DESCRIPTION
If resource method get_queryset return list, then paginator __init__ method raise an error.
