### PR TITLE
Explicit raising of assertion errors

### DIFF
--- a/adrest/resources/rpc.py
+++ b/adrest/resources/rpc.py
@@ -104,7 +104,8 @@ class RPCResource(ResourceView):
                 except TypeError:
                     raise AssertionError("Invalid RPC Call.")
 
-            assert 'method' in payload, "Invalid RPC Call."
+            if 'method' not in payload:
+                raise AssertionError("Invalid RPC Call.")
             return self.rpc_call(request, **payload)
 
         except Exception, e:
@@ -127,7 +128,8 @@ class RPCResource(ResourceView):
             args = list(as_tuple(params))
 
         method_key = "{0}.{1}".format(self.scheme_name, method)
-        assert method_key in self.methods, "Unknown method: {0}".format(method)
+        if method_key not in self.methods:
+            raise AssertionError("Unknown method: {0}".format(method))
         method = self.methods[method_key]
 
         if hasattr(method, 'request'):
@@ -160,11 +162,12 @@ class AutoJSONRPC(RPCResource):
         return object: a result
 
         """
-        assert method and self.separator in method, \
-            "Wrong method name: {0}".format(method)
+        if not method or self.separator not in method:
+            raise AssertionError("Wrong method name: {0}".format(method))
 
         resource_name, method = method.split(self.separator, 1)
-        assert resource_name in self.api.resources, "Unknown method"
+        if resource_name not in self.api.resources:
+            raise AssertionError("Unknown method " + method)
 
         data = QueryDict('', mutable=True)
         data.update(payload.get('data', dict()))


### PR DESCRIPTION
From [docs](http://docs.python.org/2/tutorial/modules.html#compiled-python-files):

```
When the Python interpreter is invoked with the -O flag, optimized code is
generated and stored in .pyo files. The optimizer currently doesn’t help
much; it only removes assert statements. When -O is used, all bytecode is
optimized; .pyc files are ignored and .py files are compiled to optimized
bytecode.
```

Of course nowadays it is useless but there is no any guarantee that
cPython/PyPy will add something tasty to such flag or change behaviour.

I concern about usage of `assert` instructions within the library: simple `-O`
flag can break some logic and invalidate whole library. So this commit
simply put some explicit assertion verification
